### PR TITLE
Updated OpenAPI Spec

### DIFF
--- a/docs/openapi/api/v1/response/error-forge-list-empty.yaml
+++ b/docs/openapi/api/v1/response/error-forge-list-empty.yaml
@@ -9,5 +9,5 @@ properties:
     type: string
     example: >-
       The forge list submited is empty. An interface should handle at 
-      least one forge
+      least one forge.
 

--- a/docs/openapi/api/v1/spec.yaml
+++ b/docs/openapi/api/v1/spec.yaml
@@ -27,7 +27,7 @@
         content:
           application/json:
             schema:
-              $ref: "./response/error-interface-unreachable.yaml"
+              $ref: "./response/error-forge-list-empty.yaml"
       '503':
         description: >-
           Registration failure, interface couldn't be reached via the URL provided


### PR DESCRIPTION
# Issue
The OpenAPI generation for the spec was not providing the required response codes for the empty forge list submission.

# Fixed
Updated the spec to contain the link to the correct `yaml` response file.