### PR TITLE
feat: verify interface online by querying nodeinfo

### DIFF
--- a/docs/openapi/api/v1/response/error-interface-unreachable.yaml
+++ b/docs/openapi/api/v1/response/error-interface-unreachable.yaml
@@ -1,0 +1,10 @@
+type: object
+properties:
+  errcode:
+    description: The F_D_INTERFACE_UNREACHABLE error code
+    type: string
+    example: F_D_INTERFACE_UNREACHABLE
+  error:
+    description: A human-readable error message
+    type: string
+    example: The interface was unreachable with the publicly accessible URL provided

--- a/docs/openapi/api/v1/spec.yaml
+++ b/docs/openapi/api/v1/spec.yaml
@@ -30,6 +30,13 @@
           application/json:
             schema:
               $ref: "./response/base-error.yaml"
+      '503':
+        description: >-
+          Registration failure, interface couldn't be reached via the URL provided
+        content:
+          application/json:
+            schema:
+              $ref: "./response/error-interface-unreachable.yaml"
 
 /api/v1/forge/interfaces:
   post:

--- a/northstar/api/v1/errors.py
+++ b/northstar/api/v1/errors.py
@@ -63,6 +63,12 @@ F_D_EMPTY_FORGE_LIST = Error(
     status=400,
 )
 
+F_D_INTERFACE_UNREACHABLE = Error(
+    errcode="F_D_INTERFACE_UNREACHABLE",
+    error="The interface was unreachable with the publicly accessible URL provided",
+    status=503,
+)
+
 F_D_INVALID_PAYLOAD = Error(
     errcode="F_D_INVALID_PAYLOAD",
     error="Please submit valid payload",

--- a/northstar/api/v1/interface.py
+++ b/northstar/api/v1/interface.py
@@ -16,12 +16,13 @@ Interface related routes
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 from flask import Blueprint, jsonify, request
-from .utils import clean_url, not_url
+from .utils import clean_url, not_url, verify_interface_online
 
 from northstar.db import get_db
 from .errors import (
     F_D_EMPTY_FORGE_LIST,
     F_D_INVALID_PAYLOAD,
+    F_D_INTERFACE_UNREACHABLE,
     F_D_NOT_URL,
 )
 
@@ -52,6 +53,9 @@ def register():
         new_forge_url.append(url)
 
     forge_url = new_forge_url
+
+    if not verify_interface_online(interface_url):
+        return F_D_INTERFACE_UNREACHABLE.get_error_resp()
 
     conn = get_db()
     cur = conn.cursor()

--- a/northstar/api/v1/utils.py
+++ b/northstar/api/v1/utils.py
@@ -42,3 +42,41 @@ def trim_url(url: str) -> str:
     if url.endswith("/"):
         url = url[0:-1]
     return url
+
+
+def verify_interface_online(url: str):
+    """Verify if interface instance is reachable"""
+    parsed = urlparse(url)
+    path = "/.well-known/nodeinfo"
+    url = urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+    resp = requests.get(url)
+    if resp.status_code != 200:
+        print("first stage")
+        return False
+    data = resp.json()
+    if "links" not in data:
+        print("sec sec stage")
+        return False
+    for nodeinfo in data["links"]:
+        if any(["href" not in nodeinfo, "rel" not in nodeinfo]):
+            print("sec stage")
+            return False
+        if "http://nodeinfo.diaspora.software/ns/schema/2.0" not in nodeinfo["rel"]:
+            print("thir stage")
+            return False
+        resp = requests.get(nodeinfo["href"])
+        if resp.status_code != 200:
+            print("4 stage")
+            return False
+        data = resp.json()
+        if "metadata" not in data:
+            print("5 stage")
+            return False
+        metadata = data["metadata"]
+        if "forgeflux-protocols" not in metadata:
+            print("6 stage")
+            return False
+
+        print("final stage")
+        return "interface.forgeflux.org" in metadata["forgeflux-protocols"]
+    return False

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -15,14 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from northstar.app import create_app
 
-from northstar.api.v1.errors import (
-    Error,
-    F_D_EMPTY_FORGE_LIST,
-    F_D_NO_REGISTERED_INTERFACES,
-    F_D_INVALID_PAYLOAD,
-    F_D_INTERNAL_SERVER_ERROR,
-    F_D_NOT_URL,
-)
+from northstar.api.v1.errors import Error
+from northstar.api.v1.interface import F_D_EMPTY_FORGE_LIST, F_D_INTERFACE_UNREACHABLE
 
 
 def test_errors(client):
@@ -34,7 +28,4 @@ def test_errors(client):
         assert resp.status.find(str(status)) is not -1
 
     verify_status(F_D_EMPTY_FORGE_LIST, 400)
-    verify_status(F_D_NO_REGISTERED_INTERFACES, 400)
-    verify_status(F_D_INTERNAL_SERVER_ERROR, 500)
-    verify_status(F_D_INVALID_PAYLOAD, 400)
-    verify_status(F_D_NOT_URL, 400)
+    verify_status(F_D_INTERFACE_UNREACHABLE, 503)

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -19,12 +19,14 @@ from northstar.app import create_app
 from northstar.api.v1.errors import (
     F_D_EMPTY_FORGE_LIST,
     F_D_INVALID_PAYLOAD,
+    F_D_INTERFACE_UNREACHABLE,
     F_D_NOT_URL,
     F_D_NO_REGISTERED_INTERFACES,
 )
 from northstar.api.v1.interface import clean_url, not_url
+from northstar.api.v1.interface import verify_interface_online
 
-from test_utils import expect_error
+from test_utils import expect_error, get_nodeinfo_index, get_nodeinfo_resp
 
 
 def lookup(client, payload: str):
@@ -35,9 +37,10 @@ def lookup(client, payload: str):
 def test_lookup(client, requests_mock):
     """Test interface registration handler"""
 
-    interface_url = "https://interface.example.com/_ff/interface/versions"
-    resp = {"versions": ["v0.1.0"]}
+    base = "https://interface.example.com"
+    (interface_url, resp) = get_nodeinfo_index(base)
     requests_mock.get(interface_url, json=resp)
+    requests_mock.get(resp["links"][0]["href"], json=get_nodeinfo_resp())
 
     forges = ["https://forge.example.com", "ssh://forge.example.com"]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,3 +39,30 @@ def test_trim_url():
     path = "/foo/bar"
     assert trim_url(path) == path
     assert trim_url(f"{path}/") == path
+
+
+def get_nodeinfo_index(base: str):
+    resp = {
+        "links": [
+            {
+                "href": f"{base}/.well-known/nodeinfo/2.0.json",
+                "rel": "http://nodeinfo.diaspora.software/ns/schema/2.0",
+            }
+        ]
+    }
+    return (f"{base}/.well-known/nodeinfo", resp)
+
+
+def get_nodeinfo_resp():
+    nodeinfo = {
+        "version": "2.0",
+        "software": {
+            "name": "ForgeFlux Interface",
+            "version": "0.1.0-alpha",
+        },
+        "services": {"inbound": [], "outbound": []},
+        "protocols": ["activitypub"],
+        "openRegistrations": False,
+        "metadata": {"forgeflux-protocols": ["interface.forgeflux.org"]},
+    }
+    return nodeinfo


### PR DESCRIPTION
## Changes:

- Error type `F_DINTERFACE_UNREACHABLE` is redefined
- `verify_interface_online` queries nodeinfo under the hood