### PR TITLE
fix: run migrations after app instance dir is created

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM python:3.10-slim-bullseye
 LABEL org.opencontainers.image.source https://github.com/forgeflux-org/northstar
 
 RUN useradd -ms /bin/bash -u 1001 northstar
-RUN apt-get update && apt-get install -y ca-certificates make git
+RUN apt-get update && apt-get install -y ca-certificates git
 USER northstar
 
 RUN mkdir -p /home/northstar/app/northstar/static/docs/openapi
@@ -31,7 +31,6 @@ RUN sed -i '/.\//d' requirements.txt
 RUN ./venv/bin/pip install --use-feature=in-tree-build -r requirements.txt
 COPY . .
 ENV FLASK_APP=northstar/__init__.py
-RUN make migrate
 COPY --from=docs /src/northstar/static/docs/openapi/ \
 	/home/northstar/app/northstar/static/docs/openapi/
 CMD [ "./venv/bin/gunicorn",  "-w", "4", "-b", "0.0.0.0:3000", "--", "northstar:app"]

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ lint: ## Run linter
 	@./venv/bin/black ./tests/*
 
 migrate: ## Run migrations
-	@. ./venv/bin/activate && FLASK_APP=northstar/app.py FLASK_ENV=development flask migrate
+	@- mkdir instance/
+	@ venv/bin/yoyo-migrate apply --all --batch
+
 
 test: doc ## Run tests
 	@cd ./docs/openapi/  && yarn install 

--- a/northstar/app.py
+++ b/northstar/app.py
@@ -27,19 +27,18 @@ from .pages import bp as pages
 def create_app(test_config=None):
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
-    app.config.from_mapping(
-        DATABASE=os.path.join(app.instance_path, "northstar.db"),
-    )
 
-    db.init_app(app)
-
-    if test_config is None:
-        app.config.from_pyfile("config.py", silent=True)
-    else:
+    if test_config:
         app.config.from_mapping(test_config)
+
+    if "DATABASE" not in app.config:
+        app.config.from_mapping(
+            DATABASE=os.path.join(app.instance_path, "northstar.db"),
+        )
 
     try:
         os.makedirs(app.instance_path)
+        db.init_app(app)
     except OSError:
         pass
 

--- a/northstar/db/conn.py
+++ b/northstar/db/conn.py
@@ -58,5 +58,7 @@ def migrate_db_command():
 
 
 def init_app(app):
+    with app.app_context():
+        init_db()
     app.teardown_appcontext(close_db)
     app.cli.add_command(migrate_db_command)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ import requests_mock
 from dynaconf import settings
 
 from northstar.app import create_app
-from northstar.db import get_db, init_db
+from northstar.db import get_db, init_app
 
 
 @pytest.fixture
@@ -36,8 +36,9 @@ def app():
         }
     )
 
+
     with app.app_context():
-        init_db()
+        init_app(app)
 
     yield app
 


### PR DESCRIPTION
> blocked by #32 

## Changes
- migrations were being run before the app instance dir was created,
  resulting in failures during app startup
- migration step and make dependency is removed from Dockerfile as
  migration is now run as part of startup routine
- conditionally load test configuration passed by pytest fixture